### PR TITLE
feat: implement a simpler breadcrumbs component

### DIFF
--- a/src/components/Breadcrumbs.astro
+++ b/src/components/Breadcrumbs.astro
@@ -1,50 +1,12 @@
 ---
+import { type BreadcrumbArray } from '../config';
 export interface Props {
-	template: string;
+	breadcrumbArray?: BreadcrumbArray;
 }
 
-import { getEntry } from 'astro:content';
-const { template } = Astro.props;
-const path = Astro.url.pathname;
-const slug = Astro.params.slug;
+const { breadcrumbArray } = Astro.props;
 
-// @TODO: în loc să ne chinuim să facem toată logica aici, ar trebui ca fiecare pagină să paseze un array pe Layout cu structura breadcrumbs
-
-let level,
-	section = {title: '', slug: ''},
-	category = {title: '', slug: ''},
-	resource = {title: '', slug: ''};
-
-// @TODO: fix this
-switch (template) {
-	case 'ResourcePage':
-		level = 3;
-		section.title = "";
-		section.slug = "/";
-		category.title = "";
-		category.slug = "/";
-		const currentResource = await getEntry('resources', slug);
-		resource.title = currentResource?.data.title;
-		resource.slug = path;
-		break;
-	case 'CategoryPage':
-		level = 2;
-		section.title = "";
-		section.slug = "/";
-		category.title = "";
-		category.slug = "/";
-		break;
-	case 'SectionPage':
-		level = 1;
-		const currentSection = await getEntry('sections', path);
-		section.title = currentSection?.data.menu;
-		section.slug = currentSection?.slug;
-		break;
-	default:
-		level = 0;
-}
 ---
-
 <nav class="Breadcrumbs">
 	<ol class="BreadcrumbList" itemscope itemtype="https://schema.org/BreadcrumbList">
 		<li class="BreadcrumbItem" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
@@ -59,23 +21,13 @@ switch (template) {
 			</a>
 			<meta itemprop="position" content="1" />
 		</li>
-		{level >= 1 && <li class="BreadcrumbItem" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-			<a class="BreadcrumbLink" itemprop="item" href={`/${section.slug}`} title={`Mergi înapoi la pagina ${section.title}`}>
-				<span class="LinkText" itemprop="name">{section.title}</span>
-				<meta itemprop="position" content="2" />
-			</a>
-		</li> }
-		{level >= 2 && <li class="BreadcrumbItem" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-			<a class="BreadcrumbLink" itemprop="item" href={`/${category.slug}`} title={`Mergi înapoi la pagina ${category.title}`}>
-				<span class="LinkText" itemprop="name">{category.title}</span>
-				<meta itemprop="position" content="3" />
-			</a>
-		</li> }
-		{level >= 3 && <li class="BreadcrumbItem" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
-			<a class="BreadcrumbLink" itemprop="item" href={resource.slug} title={`Mergi înapoi la pagina ${resource.title}`}>
-				<span class="LinkText" itemprop="name">{resource.title}</span>
-				<meta itemprop="position" content="4" />
-			</a>
-		</li> }
+		{breadcrumbArray?.map((breadcrumbItem, i) => (
+			<li class="BreadcrumbItem" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a class="BreadcrumbLink" itemprop="item" href={breadcrumbItem.href} title={`Mergi înapoi la pagina ${breadcrumbItem.title}`}>
+					<span class="LinkText" itemprop="name">{breadcrumbItem.label}</span>
+					<meta itemprop="position" content={(i+2).toString()} />
+				</a>
+			</li>
+		))}
 	</ol>
 </nav>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,10 +1,10 @@
 ---
+import { type BreadcrumbArray } from '../config';
 import Breadcrumbs from '../components/Breadcrumbs.astro';
 import { getCollection } from 'astro:content';
 import { highlightUrl } from '../utils/urlHelpers';
-
 export interface Props {
-	template: string;
+	breadcrumbArray?: BreadcrumbArray;
 	activeMenu?: string | undefined;
 }
 
@@ -12,7 +12,7 @@ const allSections = (await getCollection('sections', ({data}) => {
 	return data.sortOrder >= 0; // negative sort orders removes sections altogether
 })).sort((a, b) => a.data.sortOrder - b.data.sortOrder); // ordering by sortOrder asc
 
-const { template, activeMenu } = Astro.props;
+const { breadcrumbArray, activeMenu } = Astro.props;
 const activePage = activeMenu || Astro.url.pathname.substring(1);
 ---
 
@@ -60,7 +60,7 @@ const activePage = activeMenu || Astro.url.pathname.substring(1);
 			</form>
 		</nav>
 	</div>
-	<Breadcrumbs template={template} />
+	<Breadcrumbs breadcrumbArray={breadcrumbArray} />
 </header>
 
 <script>

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,4 +14,10 @@ export const ACCENT_COLOR = "#2f8ded";
 export const OG_IMAGE = "../public/ogimage.jpg";
 export const OG_IMAGE_ALT = ""; //					🛑 @TODO: OG Image ALT
 export const GLOBAL_PUB_DATE = "2023-09-30T19:35:55+03:00";
-export const PAGE_SIZE = 2;
+export const PAGE_SIZE = 10;
+
+export type BreadcrumbArray = {
+	href: string | URL;
+	title: string;
+	label: string;
+}[];

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import '../style/style.scss';
 import { ACCENT_COLOR, CONTACT_EMAIL, FACEBOOK_APP_ID, LANGUAGE, LANGUAGE_EXTENDED, OG_IMAGE, OG_IMAGE_ALT, SITE_DESCRIPTION, SITE_NAME, SITE_TITLE, TWITTER_CREATOR, TWITTER_SITE } from '../config';
+import { type BreadcrumbArray } from '../config';
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';
 import { ViewTransitions } from 'astro:transitions';
@@ -15,6 +16,7 @@ interface Props {
 	canonical?: string;
 	template: string;
 	activeMenu?: string;
+	breadcrumbArray?: BreadcrumbArray;
 }
 
 const buildDate = __DATE__;
@@ -27,7 +29,8 @@ const {
 	addDate,
 	canonical = Astro.url,
 	template,
-	activeMenu
+	activeMenu,
+	breadcrumbArray
 } = Astro.props;
 
 ---
@@ -88,7 +91,7 @@ const {
 		<a id="skip" href="#hero" title="Mergi direct la conținutul acestei pagini">Mergi la conținut</a>
 		<div class="Framework">
 			<p class="TemporaryMessage">Template: <strong>{template}</strong> built at <em>{buildDate}</em>.</p>
-			<Header template={template} activeMenu={activeMenu} />
+			<Header breadcrumbArray={breadcrumbArray} activeMenu={activeMenu} />
 			<slot />
 			<Footer activeMenu={activeMenu} />
 		</div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,11 +1,17 @@
 ---
 import Layout from '../layouts/Layout.astro';
+const breadcrumbArray = [{
+	href: Astro.url,
+	title: "Pagina nu a fost găsită",
+	label: "Eroare 404"
+}];
 ---
 
 <Layout
 	title="Eroare 404: Pagina nu a fost găsită - Resurse.dev"
 	description="Ne pare rău, dar se pare că ai dat peste o pagină inexistentă pe site-ul Resurse.dev - contactează-ne dacă ai probleme."
 	template="ErrorPage"
+	breadcrumbArray={breadcrumbArray}
 >
 	<div class="Hero" id="hero">
 		<div class="HeroText">

--- a/src/pages/[section]/[...page].astro
+++ b/src/pages/[section]/[...page].astro
@@ -30,8 +30,20 @@ const currentSection = params.section as string;
 const section = await getEntry("sections", currentSection) as CollectionEntry<"sections">;
 const { Content } = await section.render();
 
+const breadcrumbArray = [{
+	href: `/${section.slug}`,
+	title: section.data.title,
+	label: section.data.menu
+}];
+
 ---
-<Layout title={section.data.title} description={section.data.description} template="SectionPage" activeMenu={section.slug}>
+<Layout
+	title={section.data.title}
+	description={section.data.description}
+	template="SectionPage"
+	activeMenu={section.slug}
+	breadcrumbArray={breadcrumbArray}
+>
 	<div class="Hero" id="hero">
 		<div class="HeroVisual">
 			<img class="HeroImage" src={section.data.image?.imageUrl} width="287" height="120" alt={section.data.image?.imageAlt} />

--- a/src/pages/[section]/[category]/[...page].astro
+++ b/src/pages/[section]/[category]/[...page].astro
@@ -19,6 +19,7 @@ export async function getStaticPaths ({ paginate }: any) {
 		const currentSection = allSections.find((sec:CollectionEntry<"sections">) => (sec.slug == section));
 		if (currentSection == null || currentSection.data.categories == null) {
 			// nu se poate sa nu existe o sectiune definita
+			// eslint-disable-next-line no-console
 			// console.warn('false', 'currentSection', currentSection?.id);
 		} else {
 			// există secțiunea
@@ -28,6 +29,7 @@ export async function getStaticPaths ({ paginate }: any) {
 			if (selectedCategories.length < 1) {
 				// secțiunea nu are categorii
 				// caz tratat în `/src/pages/[sections]/[...page].astro`
+				// eslint-disable-next-line no-console
 				// console.warn('false', 'selectedCategories', selectedCategories);
 			} else {
 				// există cel puțin o categorie pe care o putem adăuga în lista paginilor
@@ -42,6 +44,7 @@ export async function getStaticPaths ({ paginate }: any) {
 					});
 					if (selectedResources.length < 1) {
 						// nu avem resurse atașate categoriei în general
+						// eslint-disable-next-line no-console
 						// console.warn('false', 'selectedResources', selectedResources);
 						finalPagination.push({
 							params: {
@@ -95,8 +98,24 @@ const currentCategory = params.category as string;
 const category = await getEntry("categories", currentCategory) as CollectionEntry<"categories">;
 const { Content } = await category.render();
 
+const breadcrumbArray = [{
+	href: `/${section.slug}`,
+	title: section.data.title,
+	label: section.data.menu
+}, {
+	href: `/${section.slug}/${category.slug}`,
+	title: category.data.title,
+	label: category.data.menu
+}];
+
 ---
-<Layout title={category.data.title} description={category.data.description} template="CategoryPage" activeMenu={section.slug}>
+<Layout
+	title={category.data.title}
+	description={category.data.description}
+	template="CategoryPage"
+	activeMenu={section.slug}
+	breadcrumbArray={breadcrumbArray}
+>
 	<div class="Hero" id="hero">
 		<div class="HeroVisual">
 			<img class="HeroImage" src={category.data.image?.imageUrl} width="287" height="120" alt={category.data.image?.imageAlt} />

--- a/src/pages/[section]/[category]/[subcategory]/[...page].astro
+++ b/src/pages/[section]/[category]/[subcategory]/[...page].astro
@@ -21,6 +21,7 @@ export async function getStaticPaths ({ paginate }: any) {
 		const currentSection = allSections.find((sec:CollectionEntry<"sections">) => (sec.slug == section));
 		if (currentSection == null || currentSection.data.categories == null) {
 			// nu se poate sa nu existe o sectiune definita
+			// eslint-disable-next-line no-console
 			// console.warn('false', 'currentSection', currentSection?.id);
 		} else {
 			// există secțiunea
@@ -30,6 +31,7 @@ export async function getStaticPaths ({ paginate }: any) {
 			if (selectedCategories.length < 1) {
 				// secțiunea nu are categorii
 				// caz tratat în `/src/pages/[sections]/[...page].astro`
+				// eslint-disable-next-line no-console
 				// console.warn('false', 'selectedCategories', selectedCategories);
 			} else {
 				// există cel puțin o categorie pe care o putem adăuga în lista paginilor
@@ -38,6 +40,7 @@ export async function getStaticPaths ({ paginate }: any) {
 					const currentCategory = allCategories.find((cat:CollectionEntry<"categories">) => (cat.slug == category));
 					if (!currentCategory || currentCategory.data.subcategories == null) {
 						// nu avem subcategorii în categoria curentă
+						// eslint-disable-next-line no-console
 						// console.warn('false', 'currentCategory', currentCategory?.id);
 					} else {
 						// există cel puțin o subcategorie pe care o putem adăuga în lista paginilor
@@ -46,6 +49,7 @@ export async function getStaticPaths ({ paginate }: any) {
 						if (selectedSubCategories.length < 1) {
 							// categoria nu are subcategorii
 							// caz tratat în `/src/pages/[sections]/[categories]/[...page].astro`
+							// eslint-disable-next-line no-console
 							// console.warn('false', 'selectedSubCategories', selectedSubCategories);
 						} else {
 							// există cel puțin o subcategorie pe care o putem adăuga în lista paginilor
@@ -59,6 +63,7 @@ export async function getStaticPaths ({ paginate }: any) {
 								});
 								if (selectedResources.length < 1) {
 									// nu avem resurse atașate categoriei în general
+									// eslint-disable-next-line no-console
 									// console.warn('false', 'selectedResources', selectedResources);
 									finalPagination.push({
 										params: {
@@ -116,8 +121,29 @@ const category = await getEntry("categories", currentCategory) as CollectionEntr
 const currentSubCategory = params.subcategory as string;
 const subcategory = await getEntry("subcategories", currentSubCategory) as CollectionEntry<"subcategories">;
 const { Content } = await category.render();
+
+const breadcrumbArray = [{
+	href: `/${section.slug}`,
+	title: section.data.title,
+	label: section.data.menu
+}, {
+	href: `/${section.slug}/${category.slug}`,
+	title: category.data.title,
+	label: category.data.menu
+}, {
+	href: `/${section.slug}/${category.slug}/${subcategory.slug}`,
+	title: subcategory.data.title,
+	label: subcategory.data.menu
+}];
+
 ---
-<Layout title={subcategory.data.title} description={subcategory.data.description} template="SubcategoryPage" activeMenu={section.slug}>
+<Layout
+	title={subcategory.data.title}
+	description={subcategory.data.description}
+	template="SubcategoryPage"
+	activeMenu={section.slug}
+	breadcrumbArray={breadcrumbArray}
+>
 	<div class="Hero" id="hero">
 		<div class="HeroVisual">
 			<img class="HeroImage" src={subcategory.data.image?.imageUrl} width="287" height="120" alt={subcategory.data.image?.imageAlt} />

--- a/src/pages/confidentialitate.astro
+++ b/src/pages/confidentialitate.astro
@@ -1,8 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
+const breadcrumbArray = [{
+	href: Astro.url,
+	title: "Politică de confidențialitate",
+	label: "Confidențialitate"
+}];
 ---
 
-<Layout title="Politică de confidențialitate - Resurse.dev" description="@TODO: scrie descrierea" template="PrivacyPage">
+<Layout title="Politică de confidențialitate - Resurse.dev" description="@TODO: scrie descrierea" template="PrivacyPage" breadcrumbArray={breadcrumbArray}>
 	<div class="Hero" id="hero">
 		<div class="HeroText">
 			<h1 class="HeroTitle">Politică de confidențialitate</h1>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,8 +1,13 @@
 ---
 import Layout from "../layouts/Layout.astro";
+const breadcrumbArray = [{
+	href: Astro.url,
+	title: "Contactează-ne acum",
+	label: "Contact"
+}];
 ---
 
-<Layout title="Contactează-ne acum - Resurse.dev" description="@TODO: scrie descrierea" template="ContactPage">
+<Layout title="Contactează-ne acum - Resurse.dev" description="@TODO: scrie descrierea" template="ContactPage" breadcrumbArray={breadcrumbArray}>
 	<div class="Hero" id="hero">
 		<div class="HeroText">
 			<h1 class="HeroTitle">Contact</h1>

--- a/src/pages/cookies.astro
+++ b/src/pages/cookies.astro
@@ -1,8 +1,13 @@
 ---
 import Layout from "../layouts/Layout.astro";
+const breadcrumbArray = [{
+	href: Astro.url,
+	title: "Politică de cookies",
+	label: "Cookies"
+}];
 ---
 
-<Layout title="Politică de cookies - Resurse.dev" description="@TODO: scrie descrierea" template="CookiesPage">
+<Layout title="Politică de cookies - Resurse.dev" description="@TODO: scrie descrierea" template="CookiesPage" breadcrumbArray={breadcrumbArray}>
 	<div class="Hero" id="hero">
 		<div class="HeroText">
 			<h1 class="HeroTitle">Politică de cookies</h1>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -1,8 +1,13 @@
 ---
 import Layout from "../layouts/Layout.astro";
+const breadcrumbArray = [{
+	href: Astro.url,
+	title: "Întrebări frecvente",
+	label: "FAQ"
+}];
 ---
 
-<Layout title="Întrebări frecvente - Resurse.dev" description="@TODO: scrie descrierea" template="FAQPage">
+<Layout title="Întrebări frecvente - Resurse.dev" description="@TODO: scrie descrierea" template="FAQPage" breadcrumbArray={breadcrumbArray}>
 	<div class="Hero" id="hero">
 		<div class="HeroText">
 			<h1 class="HeroTitle">Întrebări frecvente</h1>

--- a/src/pages/resurse/[slug].astro
+++ b/src/pages/resurse/[slug].astro
@@ -30,9 +30,27 @@ let resourceSubCategories = new Array();
 if (entry.data.subcategories) {
 	resourceSubCategories = await getEntries(entry.data.subcategories) as CollectionEntry<"resources">[];
 }
+
+const breadcrumbArray = [{
+	href: "/resurse",
+	title: "Toate resursele",
+	label: "Resurse"
+},{
+	href: Astro.url,
+	title: entry.data.title,
+	label: entry.data.title
+}];
 ---
 
-<Layout title={entry.title} description={entry.data.description} modDate={entry.modDate} addDate={entry.addDate} template="ResourcePage" activeMenu={sectionSlug}>
+<Layout
+	title={entry.title}
+	description={entry.data.description}
+	modDate={entry.modDate}
+	addDate={entry.addDate}
+	template="ResourcePage"
+	activeMenu={sectionSlug}
+	breadcrumbArray={breadcrumbArray}
+>
 	<div class="Hero" id="hero">
 		<div class="HeroVisual">
 			<img class="HeroImage" src={entry.data.image.imageUrl} width="287" height="120" alt={entry.data.image.alt} />

--- a/src/pages/resurse/index.astro
+++ b/src/pages/resurse/index.astro
@@ -6,9 +6,14 @@ import ResourceList from '../../components/ResourceList.astro';
 import { getCollection } from 'astro:content';
 
 const resources = await getCollection('resources');
+const breadcrumbArray = [{
+	href: Astro.url,
+	title: "Toate resursele",
+	label: "Resurse"
+}];
 ---
 
-<Layout title="@TODO SectionPageIndex" description="@TODO: scrie descrierea" template="SectionPageIndex">
+<Layout title="Toate resursele de pe Resurse.dev" description="@TODO: scrie descrierea" template="SectionPageIndex" breadcrumbArray={breadcrumbArray}>
 	<div class="Hero" id="hero">
 		<div class="HeroText">
 			<h1 class="HeroTitle">Toate resursele</h1>

--- a/src/pages/taguri/[slug].astro
+++ b/src/pages/taguri/[slug].astro
@@ -17,9 +17,20 @@ const { Content } = await tag.render();
 
 const resources = (await getCollection("resources", ({data}) => {
 	return data.tags.find((t) => t.slug == tag.slug);
-})).sort((a, b) => (new Date(a.data.modDate as string).valueOf() - new Date(b.data.modDate as string).valueOf())) as CollectionEntry<"resources">[]; // ordering by sortOrder asc
+})).sort((a, b) => (new Date(a.data.modDate as string).valueOf() - new Date(b.data.modDate as string).valueOf())) as CollectionEntry<"resources">[];
+
+const breadcrumbArray = [{
+	href: "/taguri",
+	title: "Tag-uri",
+	label: "Tag-uri"
+},{
+	href: Astro.url,
+	title: tag.data.title,
+	label: tag.data.title
+}];
+
 ---
-<Layout title={`Tag: ${tag.data.title}`} description={tag.data.description} template="TagIndex">
+<Layout title={`Tag: ${tag.data.title}`} description={tag.data.description} template="TagIndex" breadcrumbArray={breadcrumbArray}>
 	<div class="Hero" id="hero">
 		<div class="HeroText">
 			<h1 class="HeroTitle">Tag: {tag.data.title}</h1>

--- a/src/pages/taguri/index.astro
+++ b/src/pages/taguri/index.astro
@@ -2,10 +2,15 @@
 import Layout from '../../layouts/Layout.astro';
 import { getCollection } from 'astro:content';
 
+const breadcrumbArray = [{
+	href: Astro.url,
+	title: "Tag-uri",
+	label: "Tag-uri"
+}];
 const allTags = await getCollection('tags');
 ---
 
-<Layout title="Tag-uri" description="@TODO: scrie descrierea" template="TagIndex">
+<Layout title="Tag-uri" description="@TODO: scrie descrierea" template="TagIndex" breadcrumbArray={breadcrumbArray}>
 	<div class="Hero" id="hero">
 		<div class="HeroText">
 			<h1 class="HeroTitle">Tag-urile resurselor</h1>

--- a/src/pages/termeni-si-conditii.astro
+++ b/src/pages/termeni-si-conditii.astro
@@ -1,8 +1,14 @@
 ---
 import Layout from "../layouts/Layout.astro";
+const breadcrumbArray = [{
+	href: Astro.url,
+	title: "Termeni și condiții legale",
+	label: "Legal"
+}];
+
 ---
 
-<Layout title="Termeni și condiții legale - Resurse.dev" description="@TODO: scrie descrierea" template="LegalPage">
+<Layout title="Termeni și condiții legale - Resurse.dev" description="@TODO: scrie descrierea" template="LegalPage" breadcrumbArray={breadcrumbArray}>
 	<div class="Hero" id="hero">
 		<div class="HeroText">
 			<h1 class="HeroTitle">Termeni și condiții legale</h1>


### PR DESCRIPTION
<!-- PR title should follow conventional commits (https://conventionalcommits.org) -->
# 📚 Description

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Instead of having complicated logic in the `Breadcrumbs` component, we exported the construction of the breadcrumbs into the pages as they have the most context for displaying the page architecture and structure.

## 🔗 Linked issue(s)

<!-- Please ensure there is an open issue and mention its number as #123 -->
Fixes #62

## ❓ Type of change

<!-- Please delete options that are not relevant and tick with an `x` the one that is. -->
- [ ] 🐞 Bug fix (non-breaking change which fixes an issue)
- [x] 📖 Content update (text or image-related updates)
- [ ] 🖼️ Design update (UI design and static template related change)
- [ ] 🆕 New page (addition or major edit for an existing page layout)
- [ ] 📓 Documentation update (improvements or additions to documentation)
- [x] 👌 Enhancement (improving an existing functionality, like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🛠️ Operational update (changes to configuration, CI/CD, procedures, etc.)
- [ ] 🛡️ Security update (a fix or update required to alleviate a cyber security issue)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)

# 📄 Changelog

<!-- List all (major) changes here if possible -->
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
- removed previous logic from `Breadcrumbs` component
- added `BreadcrumbArray` type as an array of objects that have properties that can be used to render the breadcrumbs
- implemented `breadcrumbArray` as an optional prop that comes from the page level and gets passed progressively onto `Layout`, then onto `Header` and finally onto the `Breadcrumbs` component
- note: this may be done easier by deciding on using shared states via [Nano Stores](https://docs.astro.build/en/core-concepts/sharing-state/)

# ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have manually tested the newly added functionality with no discernable errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
